### PR TITLE
녹음파일 이름 설정(녹음이 중지되고 파일명 설정)

### DIFF
--- a/app/src/main/java/com/example/ativbook62014ed/ahang01/NamePopUpActivity.java
+++ b/app/src/main/java/com/example/ativbook62014ed/ahang01/NamePopUpActivity.java
@@ -1,0 +1,49 @@
+package com.example.ativbook62014ed.ahang01;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+
+/**
+ * Created by LG PC on 2016-09-04.
+ */
+public class NamePopUpActivity extends Dialog {
+    private Button mSave;
+    private OnDismissListener _listener;
+    private EditText mFileName;
+
+    public NamePopUpActivity(Context context){
+        super(context);     //Dialog를 사용하기 위한 초기화
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_name_pop_up);
+
+        mSave = (Button)findViewById(R.id.btn_Save);
+        mFileName = (EditText)findViewById(R.id.edit_FileName);
+
+        mSave.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                if(_listener == null){  }
+                else{
+                    _listener.onDismiss(NamePopUpActivity.this);    //종료됨
+                }
+                dismiss();      //파일명이 입력이 안되어있을 시에 그냥 종료가 되는데 그 것을 막으려면 if문안에 토스트를 넣고 이 행을 지운다.
+            }
+        });
+    }
+
+    public void setOnDismissListener(OnDismissListener $listener) { //종료될때 이벤트
+        _listener = $listener ;     //꺼질때 이름을 저장
+    }
+
+    public String getName() {
+        return mFileName.getText().toString() ;
+    }
+}

--- a/app/src/main/java/com/example/ativbook62014ed/ahang01/Record.java
+++ b/app/src/main/java/com/example/ativbook62014ed/ahang01/Record.java
@@ -2,6 +2,7 @@ package com.example.ativbook62014ed.ahang01;
 
 import android.Manifest;
 import android.app.Activity;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.media.MediaPlayer;
 import android.media.MediaRecorder;
@@ -13,6 +14,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.Menu;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -162,6 +164,23 @@ public class Record extends Activity implements View.OnClickListener, MediaPlaye
     //함수끝
     private void mBtnStopRecOnClick(){
         if(mRecState == RECORDING){
+            NamePopUpActivity dialog = new NamePopUpActivity(this);     //다이얼로그 사용을 위한 선언
+            dialog.setContentView(R.layout.activity_name_pop_up);
+            WindowManager.LayoutParams params = dialog.getWindow().getAttributes();
+            params.width = 1000;
+            params.height = 350;
+            dialog.getWindow().setAttributes(params);
+            dialog.setOnDismissListener(new DialogInterface.OnDismissListener() {
+                @Override
+                public void onDismiss(DialogInterface $dialog) {
+                    NamePopUpActivity dialog = (NamePopUpActivity) $dialog;
+                    String name = dialog.getName();
+                    File prefile =  new File(mFilePath + mFileName);
+                    mFileName = "/AH_" + name + "Rec.mp4";
+                    prefile.renameTo(new File(mFilePath + mFileName));
+                }
+            });
+            dialog.show();      //다이얼로그 띄우기
             Toast.makeText(Record.this, mTime.getText(), Toast.LENGTH_SHORT).show();
             mBtnStartRec.setClickable(true);
             mBtnStopRec.setClickable(false);

--- a/app/src/main/res/layout/activity_name_pop_up.xml
+++ b/app/src/main/res/layout/activity_name_pop_up.xml
@@ -1,0 +1,39 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:id="@+id/popup_name"
+              android:layout_width="fill_parent"
+              android:layout_height="fill_parent"
+              android:orientation="vertical"
+              android:padding="10sp">
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="녹음 파일명 : "
+            android:textSize="20dp"
+            android:id="@+id/textView"/>
+
+        <EditText
+            android:layout_width="200dp"
+            android:singleLine = "true"
+            android:lines = "1"
+            android:layout_height="wrap_content"
+            android:id="@+id/edit_FileName"/>
+
+    </LinearLayout>
+
+    <Button
+        android:layout_gravity="center"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="저장"
+        android:id="@+id/btn_Save"/>
+
+
+</LinearLayout>
+ 


### PR DESCRIPTION
처음에 녹음이 시작될때는 녹음파일명이 임의(핸드폰의 년도 및 날짜, 시간)로 설정이 됩니다.
하지만 녹음이 완료가 되면(사용자가 중지 버튼을 눌렀을 때) 다이얼로그가 팝업되며 사용자는 원하는 파일 이름을 적고 저장버튼을 누르게됩니다. 그때 임의(핸드폰의 년도 및 날짜, 시간)로 설정된 파일의 이름이 사용자가 원하는 이름으로 변경이 되게 했습니다.
